### PR TITLE
Move grunt dependecy from dependencies to devDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   "scripts": {
     "test": "grunt test"
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "grunt": ">= 0.3.8"
   },
-  "devDependencies": {},
   "keywords": [
     "gruntplugin"
   ]


### PR DESCRIPTION
The goal is to avoid downloading grunt and all its dependencies when installing grunt-bump package through Npm.
