### PR TITLE
Set version number using git-describe

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Add this line to your project's `Gruntfile.js`:
 Let's say current version is `0.0.1`.
 
 ````
-grunt bump
+$ grunt bump
 >> Version bumped to 0.0.2
 >> Committed as "Release v0.0.2"
 >> Tagged as "v0.0.2"
 >> Pushed to origin
 
-grunt bump:patch
+$ grunt bump:patch
 >> Version bumped to 0.0.3
 >> Committed as "Release v0.0.2"
 >> Tagged as "v0.0.2"
 >> Pushed to origin
 
-grunt bump:git
+$ grunt bump:git
 >> Version bumped to 0.0.1-1-ge96c
 >> Committed as "Release v0.0.1-1-ge96c"
 >> Tagged as "v0.0.1-1-ge96c"
@@ -53,7 +53,8 @@ bump: {
     tagName: 'v%VERSION%',
     tagMessage: 'Version %VERSION%',
     push: true,
-    pushTo: 'origin'
+    pushTo: 'origin',
+    gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d' // options to use with '$ git describe'
   }
 }
 ```

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -26,7 +26,8 @@ module.exports = function(grunt) {
       tagName: 'v%VERSION%',
       tagMessage: 'Version %VERSION%',
       push: true,
-      pushTo: 'origin'
+      pushTo: 'origin',
+      gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d'
     });
 
     var template = grunt.util._.template;
@@ -51,7 +52,7 @@ module.exports = function(grunt) {
 
     // GET VERSION FROM GIT
     runIf(versionType === 'git', function(){
-      exec('git describe --tags --always --abbrev=1 --long --dirty=-d', function(err, stdout, stderr){
+      exec('git describe ' + opts.gitDescribeOptions, function(err, stdout, stderr){
         if (err) {
           grunt.fatal('Can not get a version number using `git describe`');
         }


### PR DESCRIPTION
Adds the `bump:git` command which generates a version number using [git-describe](https://www.kernel.org/pub/software/scm/git/docs/git-describe.html). 

Default command is `$ git describe --tags --always --abbrev=1 --dirty=-d`, but cli options can be set in the grunt config:

``` js
bump: {
  options: {
    // ...
    gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d'
  }
}
```
