### PR TITLE
add MIT license

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "test": "grunt test"
   },
+  "license": "MIT",
   "dependencies": {
     "semver": "~1.1"
   },


### PR DESCRIPTION
Love grunt-bump, use it all the time :-)

Please add licensing. 

This pull request will add MIT to the package so tools like npm-license will report grunt-bump as something other than an 'unknown' license.
