### PR TITLE
Bumping git version should append the short sha1 to the current version

### DIFF
--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -83,6 +83,7 @@ module.exports = function(grunt) {
       opts.files.forEach(function(file, idx) {
         var version = null;
         var content = grunt.file.read(file).replace(VERSION_REGEXP, function(match, prefix, parsedVersion, suffix) {
+          gitVersion = gitVersion && parsedVersion + '-' + gitVersion;
           version = gitVersion || semver.inc(parsedVersion, versionType || 'patch');
           return prefix + version + suffix;
         });


### PR DESCRIPTION
The use of `grunt bump:git` simply overwrote the version with the short sha1, but it should really append the sha1 to the current version which this change does.
