### PR TITLE
Document the option to bump build number

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ $ grunt bump:major
 >> Tagged as "v1.0.0"
 >> Pushed to origin
 
+$ grunt bump:build
+>> Version bumped to 1.0.0-1
+>> Committed as "Release v1.0.0-1"
+>> Tagged as "v1.0.0-1"
+>> Pushed to origin
+
 $ grunt bump:git
 >> Version bumped to 1.0.0-1-ge96c
 >> Committed as "Release v1.0.0-1-ge96c"


### PR DESCRIPTION
Running `grunt bump:build` increments the build number rather than one of the major, minor, and patch version fields.
