### PR TITLE
feat: Add option to publish to NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ bump: {
     createTag: true,
     tagName: 'v%VERSION%',
     tagMessage: 'Version %VERSION%',
+    publishNpm: false,
     push: true,
     pushTo: 'upstream',
     gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d' // options to use with '$ git describe'
@@ -125,6 +126,9 @@ If so, this is the name of that tag (`%VERSION%` placeholder is available).
 
 ### tagMessage
 Yep, you guessed right, it's the message of that tag - description (`%VERSION%` placeholder is available).
+
+### publishNpm
+If true, will execute `npm publish` to publish your changes to NPM.
 
 ### push
 Do you wanna push all these changes ?

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -28,6 +28,7 @@ module.exports = function(grunt) {
       createTag: true,
       tagName: 'v%VERSION%',
       tagMessage: 'Version %VERSION%',
+      publishNpm: false,
       push: true,
       pushTo: 'upstream',
       gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d'
@@ -172,6 +173,17 @@ module.exports = function(grunt) {
           grunt.fatal('Can not push to ' + opts.pushTo + ':\n  ' + stderr);
         }
         grunt.log.ok('Pushed to ' + opts.pushTo);
+        next();
+      });
+    });
+
+    // Publish to NPM
+    runIf(opts.publishNpm, function() {
+      exec('npm publish', function(err, stdout, stderr) {
+        if (err) {
+          grunt.fatal('Can not publish to NPM:\n  ' + stderr);
+        }
+        grunt.log.ok('Published to NPM ');
         next();
       });
     });


### PR DESCRIPTION
This PR will add the `publishNpm` option that defaults to false. If specified as true in the `options`, then it will run `npm publish` to push the recent changes to npm.
