### PR TITLE
Push to the current branch by default.

### DIFF
--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
       tagName: 'v%VERSION%',
       tagMessage: 'Version %VERSION%',
       push: true,
-      pushTo: 'upstream',
+      pushTo: '`$(git rev-parse --abbrev-ref HEAD)`',
       gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d'
     });
 


### PR DESCRIPTION
Instead of hardcoding the branch name, We can try pushing to the current branch.
