### PR TITLE
fix: Error w/ multiple files using `bump:git`

### DIFF
--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -88,8 +88,8 @@ module.exports = function(grunt) {
       opts.files.forEach(function(file, idx) {
         var version = null;
         var content = grunt.file.read(file).replace(VERSION_REGEXP, function(match, prefix, parsedVersion, suffix) {
-          gitVersion = gitVersion && parsedVersion + '-' + gitVersion;
-          version = exactVersionToSet || gitVersion || semver.inc(parsedVersion, versionType || 'patch');
+          var fileGitVersion = gitVersion && parsedVersion + '-' + gitVersion;
+          version = exactVersionToSet || fileGitVersion || semver.inc(parsedVersion, versionType || 'patch');
           return prefix + version + suffix;
         });
 


### PR DESCRIPTION
Fixes issue #42

This fix exposes an existing defect that the previous git version isn't detached when attaching a new one. For example, `0.0.1-9ae2-s` will become `0.0.1-9ae2-s-f512-b`.

This continues on, so after a few runs w/o a patch, the version becomes `0.0.1-9ae2-s-f512-b-f5ed-d`
