### PR TITLE
Allow "version = 1.2.3"

### DIFF
--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -68,7 +68,7 @@ module.exports = function(grunt) {
 
     var globalVersion; // when bumping multiple files
     var gitVersion;    // when bumping using `git describe`
-    var VERSION_REGEXP = /([\'|\"]?version[\'|\"]?[ ]*:[ ]*[\'|\"]?)([\d||A-a|.|-]*)([\'|\"]?)/i;
+    var VERSION_REGEXP = /([\'|\"]?version[\'|\"]?[ ]*[:=][ ]*[\'|\"]?)([\d||A-a|.|-]*)([\'|\"]?)/i;
 
 
     // GET VERSION FROM GIT


### PR DESCRIPTION
Updated the `VERSION_REGEXP` to allow `=`.

This is useful when you want to add the version in the source so it's accessible in the runtime environment.
For example lodash has: _.VERSION
