### PR TITLE
Adding support for grunt glob patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ bump: {
 ```
 
 ### files
-List of files to bump. Maybe you wanna bump 'component.json' as well ?
+List of files to bump. Can be either an array of files or a grunt glob ( eg: `['*.json']` ). Maybe you wanna bump 'component.json' as well ?
 
 ### updateConfigs
 Sometimes you load the content of `package.json` into a grunt config. This will update the config property, so that even tasks running in the same grunt process see the updated value.

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -85,7 +85,7 @@ module.exports = function(grunt) {
 
     // BUMP ALL FILES
     runIf(opts.bumpVersion, function(){
-      opts.files.forEach(function(file, idx) {
+      grunt.file.expand(opts.files).forEach(function(file, idx) {
         var version = null;
         var content = grunt.file.read(file).replace(VERSION_REGEXP, function(match, prefix, parsedVersion, suffix) {
           gitVersion = gitVersion && parsedVersion + '-' + gitVersion;
@@ -140,7 +140,7 @@ module.exports = function(grunt) {
     runIf(opts.commit, function() {
       var commitMessage = opts.commitMessage.replace('%VERSION%', globalVersion);
 
-      exec('git commit ' + opts.commitFiles.join(' ') + ' -m "' + commitMessage + '"', function(err, stdout, stderr) {
+      exec('git commit ' + grunt.file.expand(opts.commitFiles).join(' ') + ' -m "' + commitMessage + '"', function(err, stdout, stderr) {
         if (err) {
           grunt.fatal('Can not create the commit:\n  ' + stderr);
         }


### PR DESCRIPTION
If you want to bump and commit all *.json files you can do something like this:

``` js
bump: {
  options: {
    files: ['*.json'],
    commitFiles: ['*.json'],
  }
}
```

Also useful if you have several files in your project.
