### PR TITLE
bump:git fix

### DIFF
--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -65,10 +65,13 @@ module.exports = function(grunt) {
         queue.push(behavior);
       }
     };
+    var versionWithGit = function(parsedVersion, gitVersion) {
+      return gitVersion && parsedVersion.replace(/(\+\w+)|$/, '+' + gitVersion);
+    }
 
     var globalVersion; // when bumping multiple files
     var gitVersion;    // when bumping using `git describe`
-    var VERSION_REGEXP = /([\'|\"]?version[\'|\"]?[ ]*:[ ]*[\'|\"]?)([\d||A-a|.|-]*)([\'|\"]?)/i;
+    var VERSION_REGEXP = /([\'|\"]?version[\'|\"]?[ ]*:[ ]*[\'|\"]?)([\d||A-a|.|\-|+\w]*)([\'|\"]?)/i;
 
 
     // GET VERSION FROM GIT
@@ -88,8 +91,7 @@ module.exports = function(grunt) {
       opts.files.forEach(function(file, idx) {
         var version = null;
         var content = grunt.file.read(file).replace(VERSION_REGEXP, function(match, prefix, parsedVersion, suffix) {
-          gitVersion = gitVersion && parsedVersion + '-' + gitVersion;
-          version = exactVersionToSet || gitVersion || semver.inc(parsedVersion, versionType || 'patch');
+          version = exactVersionToSet || versionWithGit(parsedVersion, gitVersion) || semver.inc(parsedVersion, versionType || 'patch');
           return prefix + version + suffix;
         });
 


### PR DESCRIPTION
Use + instead of - to separate git version. Replace existing git version if present. Don’t concat gitVersion on multiple files.