### PR TITLE
Remove support for mandatory tag message

### DIFF
--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -155,10 +155,17 @@ module.exports = function(grunt) {
 
     // CREATE TAG
     runIf(opts.createTag, function() {
+      var hasTagMessage = Boolean(opts.tagMessage);
       var tagName = opts.tagName.replace('%VERSION%', globalVersion);
-      var tagMessage = opts.tagMessage.replace('%VERSION%', globalVersion);
+      var tagMessage = hasTagMessage && opts.tagMessage.replace('%VERSION%', globalVersion);
+      var taggingCommand = function () {
+        if ( hasTagMessage ) {
+          return 'git tag -a ' + tagName + ' -m "' + tagMessage + '"';
+        }
+        return 'git tag ' + tagName;
+      };
 
-      exec('git tag -a ' + tagName + ' -m "' + tagMessage + '"' , function(err, stdout, stderr) {
+      exec(taggingCommand(), function(err, stdout, stderr) {
         if (err) {
           grunt.fatal('Can not create the tag:\n  ' + stderr);
         }


### PR DESCRIPTION
If it’s "falsy" value, tag message won’t be included.
