### PR TITLE
fix: modify regex to enforce key name of "version"

### DIFF
--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -71,7 +71,7 @@ module.exports = function(grunt) {
 
     var globalVersion; // when bumping multiple files
     var gitVersion;    // when bumping using `git describe`
-    var VERSION_REGEXP = /([\'|\"]?version[\'|\"]?[ ]*:[ ]*[\'|\"]?)([\d||A-a|.|-]*)([\'|\"]?)/i;
+    var VERSION_REGEXP = /([\'|\"]version[\'|\"][ ]*:[ ]*[\'|\"])([\d||A-a|.|-]*)([\'|\"])/i;
 
 
     // GET VERSION FROM GIT


### PR DESCRIPTION
Currently, regex will match anything with "version" in the key name. When tracking more than one version scheme, such as "apiVersion", and if that additional scheme is the first occurrence the regex finds, the bump will be applied to that key:value. 

Change to regex removes the ? modifier for quotes which A) enforces proper JSON format and B) restricts key name for the bump target to "version" (still case insensitive).
