### PR TITLE
feat: enable different conf for each type

### DIFF
--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -20,7 +20,7 @@ var exec = require('child_process').exec;
 module.exports = function(grunt) {
 
   var DESC = 'Increment the version, commit, tag and push.';
-  grunt.registerTask('bump', DESC, function(versionType, incOrCommitOnly) {
+  grunt.registerMultiTask('bump', DESC, function(versionType, incOrCommitOnly) {
     var opts = this.options({
       bumpVersion: true,
       files: ['package.json'],


### PR DESCRIPTION
That little change makes writing configuration like this possible:

``` coffeescript
bump:
  options:
    push: false

  minor:
    options:
      push: true
      pushTo: 'canary'

  major:
    options:
      push: true
      pushTo: 'origin'
```

Closes #84
