### PR TITLE
feat: replace version globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ grunt.initConfig({
       tagMessage: 'Version %VERSION%',
       push: true,
       pushTo: 'upstream',
-      gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d'
+      gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
+      globalReplace: false
     }
   },
 })
@@ -115,6 +116,11 @@ Default value: `--tags --always --abbrev=1 --dirty=-d`
 
 Options to use with `$ git describe`
 
+#### options.globalReplace
+Type: `Boolean`
+Default value: `false`
+
+Replace all occurrences of the version in the file. When set to `false`, only the first occurrence will be replaced.
 
 ### Usage Examples
 

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -33,7 +33,8 @@ module.exports = function(grunt) {
       tagMessage: 'Version %VERSION%',
       push: true,
       pushTo: 'upstream',
-      gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d'
+      gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
+      globalReplace: false
     });
 
     if (incOrCommitOnly === 'bump-only') {
@@ -72,6 +73,12 @@ module.exports = function(grunt) {
     var globalVersion; // when bumping multiple files
     var gitVersion;    // when bumping using `git describe`
     var VERSION_REGEXP = /([\'|\"]?version[\'|\"]?[ ]*:[ ]*[\'|\"]?)([\d||A-a|.|-]*)([\'|\"]?)/i;
+
+
+    if (opts.globalReplace) {
+      // Redefine the regular expression with the _g_lobal flag in addition to the _i_gnore flag.
+      VERSION_REGEXP = new RegExp(VERSION_REGEXP.source, 'gi');
+    }
 
 
     // GET VERSION FROM GIT
@@ -127,7 +134,7 @@ module.exports = function(grunt) {
     });
 
 
-    // when only commiting, read the version from package.json / pkg config
+    // when only committing, read the version from package.json / pkg config
     runIf(!opts.bumpVersion, function() {
       if (opts.updateConfigs.length) {
         globalVersion = grunt.config(opts.updateConfigs[0]).version;


### PR DESCRIPTION
Replace the version string globally, in case it is found multiple times
in the file. Some of our files reference the version multiple times,
e.g. one time in the header and another time further down as a variable.
The current version of grunt-bump only replaces the first occurrence.
Replacing the version globally can be enabled using the new
`globalReplace` option, which by default is _false_ to keep the current
behavior as a default.
