### PR TITLE
feat: Support for prerelease identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,16 @@ $ grunt bump --setversion=2.0.1
 >> Pushed to origin
 ```
 
+If you want to specify an identifier for prerelease versions you can use the ```preid``` tag in the command line.
+
+```bash
+$ grunt bump:prerelease --preid dev
+>> Version bumped to 2.0.1-dev.0
+>> Committed as "Release v2.0.1-dev.0"
+>> Tagged as "v2.0.1-dev.0"
+>> Pushed to origin
+```
+
 Sometimes you want to run another task between bumping the version and committing, for instance generate changelog. You can use `bump-only` and `bump-commit` to achieve that:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "semver": "~2.3.0"
+    "semver": "git+ssh://git@github.com:bromanko/node-semver.git#prerelease-identifier"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "semver": "git+ssh://git@github.com:bromanko/node-semver.git#prerelease-identifier"
+    "semver": "~4.1.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -56,6 +56,8 @@ module.exports = function(grunt) {
         exactVersionToSet = false;
     }
 
+    var prereleaseIdentifier = grunt.option('preid');
+
     var done = this.async();
     var queue = [];
     var next = function() {
@@ -99,7 +101,7 @@ module.exports = function(grunt) {
         var version = null;
         var content = grunt.file.read(file).replace(VERSION_REGEXP, function(match, prefix, parsedVersion, suffix) {
           gitVersion = gitVersion && parsedVersion + '-' + gitVersion;
-          version = exactVersionToSet || gitVersion || semver.inc(parsedVersion, versionType || 'patch');
+          version = exactVersionToSet || gitVersion || semver.inc(parsedVersion, versionType || 'patch', false, prereleaseIdentifier);
           return prefix + version + suffix;
         });
 


### PR DESCRIPTION
As of semver 4.1.0 there is now support for setting a prerelease identifier.  https://github.com/npm/node-semver/issues/88

This PR adds support for passing the `preid` to semver increment. 