### PR TITLE
Explicate that the pushTo variable needs editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ grunt.initConfig({
 })
 ```
 
+You may want to change them to match your remote repository, e.g. `pushTo` might be `origin` instead of `upstream` in your case.
+
 ### Options
 
 #### options.files


### PR DESCRIPTION
- addresses issue #25
- the error message that appears if one uses the default config and does not have an `upstream` remote is a bit unclear. For a lot of users the `pushTo` config should read `origin`. This is a quick fix to hit them over the head with this relevant piece of information to allow a pain-free setup and first run.