### PR TITLE
feat: add support for non-JSON version files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Default value: `['package.json']`
 
 Maybe you wanna bump 'component.json' instead? Or maybe both: `['package.json', 'component.json']`? Can be either a list of files to bump (an array of files) or a grunt glob (e.g., `['*.json']`).
 
+Grunt-bump will scan these files searching for instances of the version-\<separator\>-\<value\> pattern where _version_ is case-insensitive, _separator_ can be either colon or equals sign and _value_ is a string following the [semantic versioning](http://semver.org) convention.  The fact the equals sign is also supported means you are not limited only to JSON files but you can use other file formats to bump versions as well.
+
 #### options.updateConfigs
 Type: `Array`
 Default value: `[]`

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -72,7 +72,7 @@ module.exports = function(grunt) {
 
     var globalVersion; // when bumping multiple files
     var gitVersion;    // when bumping using `git describe`
-    var VERSION_REGEXP = /([\'|\"]?version[\'|\"]?[ ]*:[ ]*[\'|\"]?)([\d||A-a|.|-]*)([\'|\"]?)/i;
+    var VERSION_REGEXP = /([\'|\"]?version[\'|\"]?[ ]*[:|=][ ]*[\'|\"]?)([\d||A-a|.|-]*)([\'|\"]?)/i;
 
 
     if (opts.globalReplace) {


### PR DESCRIPTION
Modify the main "version : <version phrase>" regular expression to also
support equals signs as the separator.  This is to extend the
functionality to files in different formats, e.g. Ruby version files.

As a result, it is now possible to specify files with extensions other than
.json in the "files" option when configuring the plug-in.