### PR TITLE
Adding dry-run feature and potential new way of testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,21 @@ $ grunt changelog
 $ grunt bump-commit
 ```
 
+If you want to try out your settings, you can use any of the above commands with the ```dry-run``` tag in the command line.
+With this tag specified there will be no changes, stages, commits or pushes.
+
+```bash
+$ grunt bump --dry-run
+Running "bump" task
+Running grunt-bump in dry mode!
+>> bump-dry: Version bumped to 1.0.1 (in package.json)
+>> bump-dry: git commit package.json -m "Release v1.0.1"
+>> bump-dry: git tag -a v1.0.1 -m "Version 1.0.1"
+>> bump-dry: git push origin && git push origin --tags
+```
+
+Since the tag is parsed and forwarded by grunt, it will also work if you pass it to a different task which then invokes bump.
+
 ## Contributing
 See the [contributing guide](https://github.com/vojtajina/grunt-bump/blob/master/CONTRIBUTING.md) for more information. In lieu of a formal style guide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/): `grunt test jshint`.
 


### PR DESCRIPTION
Hey there,

I've implemented the dry-run feature and in order to test it I came up with the following test procedure:

1. create a testing folder in the temporary directory (`<tmp>/bump-test/`).
2. create an empty bare repository (`<tmp>/bump-test/sampleRepo.git`).
3. clone it into `<tmp>/bump-test/sampleRepo`
4. copy contents from `grunt-bump/test/sampleRepo`
5. copy grunt, semver and the essential parts of grunt-bump into `<tmp>/bump-test/sampleRepo/node_modules`
6. test grunt-bump using execSync to run `git ...` and `grunt ...` as child processes within `<tmp>/bump-test/sampleRepo`
7. delete `<tmp>/bump-test` with all its subfolders and -directories

Currently there are some issues though.
Once #105 is merged, I might change the tests to use mocha instead of node unit... wonder how long that will take though :/

Greetings
Swen