### PR TITLE
Removed 2nd example of patch usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,19 @@ $ grunt bump --setversion=2.0.1
 >> Pushed to origin
 ```
 
+If you want to append commit message content, you can use the ```commitmsg``` tag in the command line.
+
+```bash
+$ grunt bump --commitmsg="Some notes about this commit"
+>> Version bumped to 2.0.1
+>> Committed as "Release v2.0.1 - Some notes about this commit"
+>> Tagged as "v2.0.1"
+>> Pushed to origin
+```
+
+
+
+
 Sometimes you want to run another task between bumping the version and committing, for instance generate changelog. You can use `bump-only` and `bump-commit` to achieve that:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -157,12 +157,6 @@ $ grunt bump:prerelease
 >> Tagged as "v1.0.0-1"
 >> Pushed to origin
 
-$ grunt bump:patch
->> Version bumped to 1.0.1
->> Committed as "Release v1.0.1"
->> Tagged as "v1.0.1"
->> Pushed to origin
-
 $ grunt bump:git
 >> Version bumped to 1.0.1-ge96c
 >> Committed as "Release v1.0.1-ge96c"

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -56,6 +56,16 @@ module.exports = function(grunt) {
         exactVersionToSet = false;
     }
 
+
+    //Use: --commitmsg="add me to commit message"
+    var appendToCommitMessage = grunt.option('commitmsg');
+    if ( !appendToCommitMessage || appendToCommitMessage.length == 0 ) {
+        appendToCommitMessage = '';
+    } else {
+      appendToCommitMessage = ' - '.concat(appendToCommitMessage);
+    }
+
+
     var done = this.async();
     var queue = [];
     var next = function() {
@@ -148,7 +158,7 @@ module.exports = function(grunt) {
 
     // COMMIT
     runIf(opts.commit, function() {
-      var commitMessage = opts.commitMessage.replace('%VERSION%', globalVersion);
+      var commitMessage = opts.commitMessage.replace('%VERSION%', globalVersion) + appendToCommitMessage;
 
       exec('git commit ' + opts.commitFiles.join(' ') + ' -m "' + commitMessage + '"', function(err, stdout, stderr) {
         if (err) {
@@ -176,7 +186,7 @@ module.exports = function(grunt) {
 
 
     // PUSH CHANGES
-    runIf(opts.push, function() {
+    runIf( opts.push, function() {
       exec('git push ' + opts.pushTo + ' && git push ' + opts.pushTo + ' --tags', function(err, stdout, stderr) {
         if (err) {
           grunt.fatal('Can not push to ' + opts.pushTo + ':\n  ' + stderr);


### PR DESCRIPTION
Sorry for the PR mess. Still getting the hang of this. Looks like I should have branched before adding the feature (after README.md change) and then I could have done a compare with a seperate branch. Below find what should have been the info for 2 different PRs.

docs(grunt-bump): Removes a potentially confusing and redundant example in README.md

feat(grunt-bump): Adds commitmsg option to allow for appending commit messages at the command line