### PR TITLE
Fixes issue 42 and 94.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ grunt.initConfig({
       push: true,
       pushTo: 'upstream',
       gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
-      globalReplace: false
+      globalReplace: false,
+      prereleaseName: null
     }
   },
 })
@@ -124,6 +125,19 @@ Default value: `false`
 
 Replace all occurrences of the version in the file. When set to `false`, only the first occurrence will be replaced.
 
+#### options.prereleaseName
+Type: `String`
+Default value: `rc`
+
+When bumping to a prerelease version this will be the identifier of the prerelease e.g. `dev`, `alpha`, `beta`, `rc` etc.
+1.0.0-`prereleaseName`.0
+When left as the default `null` version bump:prereleae will behave as follows:
+* 1.0.0   to 1.0.1-0
+* 1.0.1-0 to 1.0.1-1
+* from a previous bump:git
+  * 1.0.0-7-g10b5 to 1.0.0-8
+
+
 ### Usage Examples
 
 Let's say current version is `0.0.1`.
@@ -153,12 +167,6 @@ $ grunt bump:major
 >> Tagged as "v1.0.0"
 >> Pushed to origin
 
-$ grunt bump:prerelease
->> Version bumped to 1.0.0-1
->> Committed as "Release v1.0.0-1"
->> Tagged as "v1.0.0-1"
->> Pushed to origin
-
 $ grunt bump:patch
 >> Version bumped to 1.0.1
 >> Committed as "Release v1.0.1"
@@ -169,6 +177,54 @@ $ grunt bump:git
 >> Version bumped to 1.0.1-ge96c
 >> Committed as "Release v1.0.1-ge96c"
 >> Tagged as "v1.0.1-ge96c"
+>> Pushed to origin
+
+$ grunt bump:prepatch
+>> Version bumped to 1.0.2-0
+>> Committed as "Release v1.0.2-0"
+>> Tagged as "v1.0.2-0"
+>> Pushed to origin
+
+$ grunt bump:prerelease
+>> Version bumped to 1.0.2-1
+>> Committed as "Release v1.0.2-1"
+>> Tagged as "v1.0.2-1"
+>> Pushed to origin
+
+$ grunt bump:patch # (major, minor or patch) will do this
+>> Version bumped to 1.0.2
+>> Committed as "Release v1.0.2"
+>> Tagged as "v1.0.2"
+>> Pushed to origin
+
+$ grunt bump:preminor
+>> Version bumped to 1.1.0-0
+>> Committed as "Release v1.1.0-0"
+>> Tagged as "v1.1.0-0"
+>> Pushed to origin
+
+$ grunt bump
+>> Version bumped to 1.1.0
+>> Committed as "Release v1.1.0"
+>> Tagged as "v1.1.0"
+>> Pushed to origin
+
+$ grunt bump:premajor (with prerelaseName set to 'rc' in options)
+>> Version bumped to 2.0.0-rc.0
+>> Committed as "Release v2.0.0-rc.0"
+>> Tagged as "v2.0.0-rc.0"
+>> Pushed to origin
+
+$ grunt bump
+>> Version bumped to 2.0.0
+>> Committed as "Release v2.0.0"
+>> Tagged as "v2.0.0"
+>> Pushed to origin
+
+$ grunt bump:prerelease  # from a released version `prerelease` defaults to prepatch
+>> Version bumped to 2.0.1-rc.0
+>> Committed as "Release v2.0.1-rc.0"
+>> Tagged as "v2.0.1-rc.0"
 >> Pushed to origin
 ````
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "semver": "~2.3.0"
+    "semver": "~4.2.2"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"


### PR DESCRIPTION
This fixes the issue where bump:git was not working when there were multiple files being bumped.
It also bumps the version of semver to allow for  
* premajor  
* preminor  
* prepatch  
* prerelease  

Also adds bump:release to drop the pre-release portion of a version number.
e.g. from version 1.0.1-rc2  bump:release bumps the version from the prerelease version to 1.0.1.

