### PR TITLE
Allow version as url parameter

### DIFF
--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -77,7 +77,7 @@ module.exports = function(grunt) {
 
     var globalVersion; // when bumping multiple files
     var gitVersion;    // when bumping using `git describe`
-    var VERSION_REGEXP = /([\'|\"]?version[\'|\"]?[ ]*:[ ]*[\'|\"]?)([\d||A-a|.|-]*)([\'|\"]?)/i;
+    var VERSION_REGEXP = /([\'|\"]?version[\'|\"]?[ ]*[:=][ ]*[\'|\"]?)([\d||A-a|.|-]*)([\'|\"]?)/i;
 
 
     if (opts.globalReplace) {


### PR DESCRIPTION
Hi @vojtajina,

I want to use grunt-bump to automatically update versions for web-app assets, like versioned CSS or JS files.
Usually these assets are parameterized with the current version like `<link rel="stylesheet" href="app.css?version=0.1.2">`
grunt-bump does not recognize such versions, because the REGEX pattern just doesn't catch this.

I updated the REGEX pattern to catch this type of version. I'd be happy to see that in your core.

Cheers,

Regaddi