### PR TITLE
Fix undefined `suffix`

### DIFF
--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -120,7 +120,7 @@ module.exports = function(grunt) {
             version = setVersion || semver.inc(
               parsedVersion, type || 'patch', gitVersion || opts.prereleaseName
             );
-            return prefix + version + suffix;
+            return prefix + version + (suffix ? suffix : '');
           }
         );
 

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -120,7 +120,7 @@ module.exports = function(grunt) {
             version = setVersion || semver.inc(
               parsedVersion, type || 'patch', gitVersion || opts.prereleaseName
             );
-            return prefix + version + (suffix ? suffix : '');
+            return prefix + version + (suffix || '');
           }
         );
 


### PR DESCRIPTION
Fix undefined `suffix` on version replace.
in some cases (like a custom `opts.regExp`) the `suffix` is not defined.