### PR TITLE
feat: add support for committing untracked files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ grunt.initConfig({
       commit: true,
       commitMessage: 'Release v%VERSION%',
       commitFiles: ['package.json'],
+      commitUntrackedFiles: false,
       createTag: true,
       tagName: 'v%VERSION%',
       tagMessage: 'Version %VERSION%',
@@ -83,6 +84,12 @@ Type: `Array`
 Default value: `['package.json']`
 
 An array of files that you want to commit. You can use `['--all']` to commit all files.
+
+#### options.commitUntrackedFiles
+Type: `Boolean`
+Default value: `false`
+
+Should new files be staged before being committed? Useful when creating files, such as changelogs, between the `bump-only` and `bump-commit` processes.
 
 #### options.createTag
 Type: `Boolean`

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If so, what is the commit message ? You can use `%VERSION%` which will get repla
 Type: `Array`
 Default value: `['package.json']`
 
-An array of files that you want to commit. You can use `['-a']` to commit all files.
+An array of files that you want to commit. You can use `['--all']` to commit all files.
 
 #### options.createTag
 Type: `Boolean`


### PR DESCRIPTION
Adds boolean option of `commitUntrackedFiles` with a default value of `false`. When set to `true`, the following git command is added into the `bump-dry` and `bump` flow: `git add [opts.commitFiles]`. 

As `git add` and `git commit` have different shorthands for `--all`, there is a check that converts `-a` to `--all` if a user has this value entered for `commitFiles`. The documentation has been updated to state `--all` in place of the shorthand to reduce confusion.

Closes #120 