### PR TITLE
fix: push the new tag, not all tags in repo

### DIFF
--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -220,8 +220,10 @@ module.exports = function(grunt) {
 
     // PUSH CHANGES
     runIf(opts.push, function() {
+      var tagName = opts.tagName.replace('%VERSION%', globalVersion);
+      
       var cmd = 'git push ' + opts.pushTo + ' && ';
-      cmd += 'git push ' + opts.pushTo + ' --tags';
+      cmd += 'git push ' + opts.pushTo + ' ' + tagName;
       if (dryRun) {
         grunt.log.ok('bump-dry: ' + cmd);
         next();


### PR DESCRIPTION
grunt-bump is just creating a single new tag, so it should only try to push that one instead of using `--tags`. Trying to push all tags can result in errors like the following:

```
 * [new tag]         v1.2.0 -> v1.2.0
 ! [rejected]        v1.0.0 -> v1.0.0 (already exists)
 ! [rejected]        v1.1.0 -> v1.1.0 (already exists)
 ! [rejected]        v1.1.1 -> v1.1.1 (already exists)
```