### PR TITLE
fix: push the current branch, not all branches

### DIFF
--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -221,8 +221,8 @@ module.exports = function(grunt) {
     // PUSH CHANGES
     runIf(opts.push, function() {
       var tagName = opts.tagName.replace('%VERSION%', globalVersion);
-      
-      var cmd = 'git push ' + opts.pushTo + ' && ';
+
+      var cmd = 'git push ' + opts.pushTo + ' `git rev-parse --abbrev-ref HEAD` ' +  ' && ';
       cmd += 'git push ' + opts.pushTo + ' ' + tagName;
       if (dryRun) {
         grunt.log.ok('bump-dry: ' + cmd);


### PR DESCRIPTION
While using push, the command used is git push origin which tries to push all the branches on the local. If user has more than one branch on local and some of them are updated on remote. git throws error. This commit pushes only current branch.