### PR TITLE
Added option to push the tag only and not the branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ grunt.initConfig({
       tagName: 'v%VERSION%',
       tagMessage: 'Version %VERSION%',
       push: true,
+      pushTagOnly: false,
       pushTo: 'upstream',
       gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
       globalReplace: false,
@@ -107,6 +108,12 @@ Type: `Boolean`
 Default value: `true`
 
 Push the changes to a remote repo?
+
+#### options.pushTagOnly
+Type: `Boolean`
+Default value: `false`
+
+Only push the tag and not the branch?
 
 #### options.pushTo
 Type: `String`

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If `options.createTag` is set to true, then yep, you guessed right, it's the mes
 Type: `Boolean` or `String`
 Default value: `true`
 
-Push the changes to a remote repo? If `options.tag` is set to `tag`, only the tag is pushed and not the branch. When set to `branch`, only the branch is pushed. 
+Push the changes to a remote repo? If `options.push` is set to `tag`, only the tag is pushed and not the branch. If set to `branch`, only the branch is pushed and not the tag. If set to `true`, both branch and tag are pushed. If set to `false`, nothing is pushed. 
 
 #### options.pushTo
 Type: `String`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ grunt.initConfig({
       tagName: 'v%VERSION%',
       tagMessage: 'Version %VERSION%',
       push: true,
-      pushTagOnly: false,
       pushTo: 'upstream',
       gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
       globalReplace: false,
@@ -104,16 +103,10 @@ Default value: `Version %VERSION%`
 If `options.createTag` is set to true, then yep, you guessed right, it's the message of that tag - description (`%VERSION%` placeholder is available).
 
 #### options.push
-Type: `Boolean`
+Type: `Boolean` or `String`
 Default value: `true`
 
-Push the changes to a remote repo?
-
-#### options.pushTagOnly
-Type: `Boolean`
-Default value: `false`
-
-Only push the tag and not the branch?
+Push the changes to a remote repo? If `options.tag` is set to `tag`, only the tag is pushed and not the branch. When set to `branch`, only the branch is pushed. 
 
 #### options.pushTo
 Type: `String`

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -223,8 +223,12 @@ module.exports = function(grunt) {
       var tagName = opts.tagName.replace('%VERSION%', globalVersion);
 
       var cmd = "";
-      if (opts.push !== 'tag') cmd += 'git push ' + opts.pushTo + ' `git rev-parse --abbrev-ref HEAD` ' +  ' && ';
-      if (opts.push !== 'branch') cmd += 'git push ' + opts.pushTo + ' ' + tagName;
+      if (opts.push === true || opts.push === 'branch') {
+        cmd += 'git push ' + opts.pushTo + ' `git rev-parse --abbrev-ref HEAD` ' +  ' && ';
+      }
+      if (opts.push === true || opts.push === 'tag') {
+        cmd += 'git push ' + opts.pushTo + ' ' + tagName
+      };
       if (dryRun) {
         grunt.log.ok('bump-dry: ' + cmd);
         next();

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -37,6 +37,7 @@ module.exports = function(grunt) {
       globalReplace: false,
       prereleaseName: false,
       push: true,
+      pushTagOnly: false,
       pushTo: 'upstream',
       regExp: false,
       setVersion: false,
@@ -222,7 +223,8 @@ module.exports = function(grunt) {
     runIf(opts.push, function() {
       var tagName = opts.tagName.replace('%VERSION%', globalVersion);
 
-      var cmd = 'git push ' + opts.pushTo + ' `git rev-parse --abbrev-ref HEAD` ' +  ' && ';
+      var cmd = "";
+      if (!opts.pushTagOnly) cmd += 'git push ' + opts.pushTo + ' `git rev-parse --abbrev-ref HEAD` ' +  ' && ';
       cmd += 'git push ' + opts.pushTo + ' ' + tagName;
       if (dryRun) {
         grunt.log.ok('bump-dry: ' + cmd);

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -37,7 +37,6 @@ module.exports = function(grunt) {
       globalReplace: false,
       prereleaseName: false,
       push: true,
-      pushTagOnly: false,
       pushTo: 'upstream',
       regExp: false,
       setVersion: false,
@@ -224,8 +223,8 @@ module.exports = function(grunt) {
       var tagName = opts.tagName.replace('%VERSION%', globalVersion);
 
       var cmd = "";
-      if (!opts.pushTagOnly) cmd += 'git push ' + opts.pushTo + ' `git rev-parse --abbrev-ref HEAD` ' +  ' && ';
-      cmd += 'git push ' + opts.pushTo + ' ' + tagName;
+      if (opts.push !== 'tag') cmd += 'git push ' + opts.pushTo + ' `git rev-parse --abbrev-ref HEAD` ' +  ' && ';
+      if (opts.push !== 'branch') cmd += 'git push ' + opts.pushTo + ' ' + tagName;
       if (dryRun) {
         grunt.log.ok('bump-dry: ' + cmd);
         next();


### PR DESCRIPTION
The `pushTagOnly` option allows you to specify that you only want to push the tag, not the branch.