### PR TITLE
Added `bumpTag` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Default value: `false`
 
 Regex to find and replace version string in files described in `options.files`. If no value is specified, it will use the plugin's default.
 
+#### options.bumpTag
+Type: `Boolean`
+Default value: `false`
+
+Bump the version based on git tags rather than relying on the version in `package.json`.
+
 ### Usage Examples
 
 Let's say current version is `0.0.1`.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,9 @@ Regex to find and replace version string in files described in `options.files`. 
 Type: `Boolean`
 Default value: `false`
 
-Bump the version based on git tags rather than relying on the version in `package.json`.
+Check if the bumped version already exists as a git tag. If so, continue bumping until a new version is found.
+
+When the version exists for a major version update, an error is given rather than updating to the next major version.
 
 ### Usage Examples
 

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -127,9 +127,9 @@ module.exports = function(grunt) {
     function bumpFromTag(parsedVersion) {
       var type = versionType === 'git' ? 'prerelease' : versionType;
       var version = parsedVersion;
-      var tagName;
+      var tagName = opts.tagName.replace('%VERSION%', version);
       
-      do {
+      while (gitTags.indexOf(tagName) >= 0) {
         version = semver.inc(
           version, type || 'patch', gitVersion || opts.prereleaseName
         );
@@ -138,7 +138,7 @@ module.exports = function(grunt) {
         if (type === 'major' && gitTags.indexOf(tagName) >= 0) {
           grunt.fatal('Bump major version failed: Version ' + version + ' already exists');
         }
-      } while (gitTags.indexOf(tagName) >= 0);
+      }
 
       return version;
     }

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -37,6 +37,7 @@ module.exports = function(grunt) {
       globalReplace: false,
       prereleaseName: false,
       push: true,
+      pushTagOnly: false,
       pushTo: 'upstream',
       regExp: false,
       setVersion: false,
@@ -123,22 +124,21 @@ module.exports = function(grunt) {
       });
     });
 
-    function bumpFromTag(crit) {
-      var type = versionType === 'git' ? 'prerelease' : (versionType || 'patch');
-      var version = crit ? (crit + '.0.0').split('.').slice(0, 3).join('.') : '0.1.0';
-      var cl = crit.split('.').length;
+    function bumpFromTag(parsedVersion) {
+      var type = versionType === 'git' ? 'prerelease' : versionType;
+      var version = parsedVersion;
+      var tagName;
       
-      if ((type === 'major' && cl > 1) || (type === 'minor' && cl > 2)) {
-        version = semver.inc(version, type, gitVersion || opts.prereleaseName);
-        if (crit) crit = version.split('.').slice(0, crit.split('.').length).join('.');
-        type = 'patch';
-      }
-
-      gitTags.forEach(function(tag) {
-        if (semver.satisfies(tag, crit) && semver.gte(tag, version)) {
-          version = semver.inc(tag, type, gitVersion || opts.prereleaseName);
+      do {
+        version = semver.inc(
+          version, type || 'patch', gitVersion || opts.prereleaseName
+        );
+        tagName = opts.tagName.replace('%VERSION%', version);
+        
+        if (type === 'major' && gitTags.indexOf(tagName) >= 0) {
+          grunt.fatal('Bump major version failed: Version ' + version + ' already exists');
         }
-      });
+      } while (gitTags.indexOf(tagName) >= 0);
 
       return version;
     }
@@ -263,7 +263,8 @@ module.exports = function(grunt) {
     runIf(opts.push, function() {
       var tagName = opts.tagName.replace('%VERSION%', globalVersion);
 
-      var cmd = 'git push ' + opts.pushTo + ' `git rev-parse --abbrev-ref HEAD` ' +  ' && ';
+      var cmd = "";
+      if (!opts.pushTagOnly) cmd += 'git push ' + opts.pushTo + ' `git rev-parse --abbrev-ref HEAD` ' +  ' && ';
       cmd += 'git push ' + opts.pushTo + ' ' + tagName;
       if (dryRun) {
         grunt.log.ok('bump-dry: ' + cmd);

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -42,6 +42,7 @@ module.exports = function(grunt) {
       setVersion: false,
       tagMessage: 'Version %VERSION%',
       tagName: 'v%VERSION%',
+      bumpTag: false,
       updateConfigs: [], // array of config properties to update (with files)
       versionType: false
     });
@@ -56,10 +57,12 @@ module.exports = function(grunt) {
 
     var globalVersion; // when bumping multiple files
     var gitVersion;    // when bumping using `git describe`
+    var gitTags;       // when bumping based on `git tag`
 
     var VERSION_REGEXP = opts.regExp || new RegExp(
-      '([\'|\"]?version[\'|\"]?[ ]*:[ ]*[\'|\"]?)(\\d+\\.\\d+\\.\\d+(-' +
-      opts.prereleaseName +
+      '([\'|\"]?version[\'|\"]?[ ]*:[ ]*[\'|\"]?)(' +
+      (opts.bumpTag ? '\\d*(?:\\.\\d+){0,2}' : '\\d+\\.\\d+\\.\\d+') +
+      '(-' + opts.prereleaseName +
       '\\.\\d+)?(-\\d+)?)[\\d||A-a|.|-]*([\'|\"]?)', 'i'
     );
     if (opts.globalReplace) {
@@ -108,6 +111,37 @@ module.exports = function(grunt) {
         next();
       });
     });
+    
+    // GET ALL TAGS FROM GIT
+    runIf(opts.bumpVersion && opts.bumpTag, function() {
+      exec('git tag', function(err, stdout) {
+        if (err) {
+          grunt.fatal('Can not get tags using `git tag`');
+        }
+        gitTags = stdout.trim().split("\n");
+        next();
+      });
+    });
+
+    function bumpFromTag(crit) {
+      var type = versionType === 'git' ? 'prerelease' : (versionType || 'patch');
+      var version = crit ? (crit + '.0.0').split('.').slice(0, 3).join('.') : '0.1.0';
+      var cl = crit.split('.').length;
+      
+      if ((type === 'major' && cl > 1) || (type === 'minor' && cl > 2)) {
+        version = semver.inc(version, type, gitVersion || opts.prereleaseName);
+        if (crit) crit = version.split('.').slice(0, crit.split('.').length).join('.');
+        type = 'patch';
+      }
+
+      gitTags.forEach(function(tag) {
+        if (semver.satisfies(tag, crit) && semver.gte(tag, version)) {
+          version = semver.inc(tag, type, gitVersion || opts.prereleaseName);
+        }
+      });
+
+      return version;
+    }
 
     // BUMP ALL FILES
     runIf(opts.bumpVersion, function() {
@@ -116,10 +150,17 @@ module.exports = function(grunt) {
         var content = grunt.file.read(file).replace(
           VERSION_REGEXP,
           function(match, prefix, parsedVersion, namedPre, noNamePre, suffix) {
-            var type = versionType === 'git' ? 'prerelease' : versionType;
-            version = setVersion || semver.inc(
-              parsedVersion, type || 'patch', gitVersion || opts.prereleaseName
-            );
+            if (setVersion) {
+              version = setVersion;
+            } else if (opts.bumpTag) {
+              version = bumpFromTag(parsedVersion);
+            } else {
+              var type = versionType === 'git' ? 'prerelease' : versionType;
+              version = semver.inc(
+                parsedVersion, type || 'patch', gitVersion || opts.prereleaseName
+              );
+            }
+            
             return prefix + version + (suffix || '');
           }
         );


### PR DESCRIPTION
With `bumpTag: true` grunt-bump will use `git tag` instead of relying solely on the version in the package.

## Examples with `bumpTag: true`

**For all examples:**

```
$ git tag
v0.1.0
v1.0.0
v1.0.1
v1.0.2
v1.1.0
v1.1.1
v2.0.0
```

```
$ grep version package.json 
  "version": "1.0.1",
$ grunt bump --dry-run
>> bump-dry: Version bumped to 1.0.3 (in package.json)
```

```
$ grep version package.json 
  "version": "1.0.1",
$ grunt bump:minor --dry-run
>> bump-dry: Version bumped to 1.2.0 (in package.json)
```

```
$ grep version package.json 
  "version": "1.0.1",
$ grunt bump:major --dry-run
Fatal error: Bump major version failed: Version 2.0.0 already exists
```

```
$ grep version package.json 
  "version": "3.0.0",
$ grunt bump --dry-run
>> bump-dry: Version bumped to 3.0.0 (in package.json)
```
