### PR TITLE
Adding option to have flags/options for the git commit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ grunt.initConfig({
       tagMessage: 'Version %VERSION%',
       push: true,
       pushTo: 'upstream',
+      gitCommitOptions: '--no-verify',
       gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
       globalReplace: false,
       prereleaseName: false,
@@ -113,6 +114,12 @@ Type: `String`
 Default value: `upstream`
 
 If `options.push` is set to true, which remote repo should it go to? This is what gets set as `remote` in the `git push {remote} {branch}` command. Use `git remote` to see the list of remote repo's you have listed. [Learn about remote repos](http://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes)
+
+#### options.gitCommitOptions
+Type: `String`
+Default value: `--no-verify`
+
+Options to use with `$ git commit`
 
 #### options.gitDescribeOptions
 Type: `String`

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -33,6 +33,7 @@ module.exports = function(grunt) {
       createTag: true,
       dryRun: false,
       files: ['package.json'],
+      gitCommitOptions: '--no-verify',
       gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
       globalReplace: false,
       prereleaseName: false,
@@ -179,7 +180,7 @@ module.exports = function(grunt) {
       var commitMessage = opts.commitMessage.replace(
         '%VERSION%', globalVersion
       );
-      var cmd = 'git commit ' + opts.commitFiles.join(' ');
+      var cmd = 'git commit ' + opts.gitCommitOptions + ' ' + opts.commitFiles.join(' ');
       cmd += ' -m "' + commitMessage + '"';
 
       if (dryRun) {


### PR DESCRIPTION
Currently I have a `pre-commit` hook that messes with `grunt bump`, in order for me to not run `pre-commit` hooks I have to add the `no-verify` flag to the command

Sadly there wasn't a way for me to do this other than include it as one of the "**files**" but that is very very dirty to do.


