### PR TITLE
Added metadata option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ grunt.initConfig({
       gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
       globalReplace: false,
       prereleaseName: false,
+      metadata: [],
       regExp: false
     }
   },
@@ -144,6 +145,12 @@ When left as the default `false` version bump:prereleae will behave as follows:
 * 1.0.1-0 to 1.0.1-1
 * from a previous bump:git
   * 1.0.0-7-g10b5 to 1.0.0-8
+  
+#### options.metadata
+Type: `Array` or `String`
+Default value: `[]`
+
+Allows optional metadata to be added as either a alphanumeric string or as an array of strings joined by a '.'.  This metadata is added to the end of the file preceded by a '+' per the semver spec.
 
 #### options.regExp
 Type: `RegExp`  

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ When left as the default `false` version bump:prereleae will behave as follows:
   * 1.0.0-7-g10b5 to 1.0.0-8
   
 #### options.metadata
-Type: `Array` or `String`
+Type: `Array` or `String` 
 Default value: `[]`
 
 Allows optional metadata to be added as either a alphanumeric string or as an array of strings joined by a '.'.  This metadata is added to the end of the file preceded by a '+' per the semver spec.

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -105,10 +105,19 @@ module.exports = function(grunt) {
         var content = grunt.file.read(file).replace(
           VERSION_REGEXP,
           function(match, prefix, parsedVersion, namedPre, noNamePre, suffix) {
+            var metadata = "";
             var type = versionType === 'git' ? 'prerelease' : versionType;
+            if(opts.metadata) {
+              if(Array.isArray(opts.metadata)) {
+                metadata = "+" + opts.metadata.join('.');
+              } else {
+                metadata = "+" + opts.metadata;
+              }
+            }
             version = setVersion || semver.inc(
               parsedVersion, type || 'patch', gitVersion || opts.prereleaseName
             );
+            version += metadata;
             return prefix + version + (suffix || '');
           }
         );


### PR DESCRIPTION
The semantic versioning documentation allows for a metadata option to be appended to the end of a version.  The format "#.#.#-rc.0+meta.tags" is a valid version format and useful in multi-deployment scenarios.