### PR TITLE
feat: add semver metadata option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ grunt.initConfig({
       gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
       globalReplace: false,
       prereleaseName: false,
+      metadata: "",
       regExp: false
     }
   },
@@ -144,6 +145,12 @@ When left as the default `false` version bump:prereleae will behave as follows:
 * 1.0.1-0 to 1.0.1-1
 * from a previous bump:git
   * 1.0.0-7-g10b5 to 1.0.0-8
+  
+#### options.metadata
+Type: `String` 
+Default value: `''`
+
+Allows optional metadata to be added as alphanumeric strings joined by a '.'.  This metadata is added to the end of the version string preceded by a '+' per the semver spec.
 
 #### options.regExp
 Type: `RegExp`  

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -19,6 +19,7 @@ module.exports = function(grunt) {
       gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
       globalReplace: false,
       prereleaseName: false,
+      metadata: '',
       push: true,
       pushTo: 'upstream',
       regExp: false,
@@ -105,10 +106,19 @@ module.exports = function(grunt) {
         var content = grunt.file.read(file).replace(
           VERSION_REGEXP,
           function(match, prefix, parsedVersion, namedPre, noNamePre, suffix) {
+            var metadata = '';
             var type = versionType === 'git' ? 'prerelease' : versionType;
+            if(opts.metadata) {
+              if(/^([0-9a-zA-Z-]+\.{0,1})*$/.test(opts.metadata)) {
+                metadata = '+' + opts.metadata;
+              } else {
+                grunt.fatal('Metadata can only contain letters, numbers, and dashes (-) connected by a dot (.)');
+              }
+            }
             version = setVersion || semver.inc(
               parsedVersion, type || 'patch', gitVersion || opts.prereleaseName
             );
+            version += metadata;
             return prefix + version + (suffix || '');
           }
         );


### PR DESCRIPTION
The semver spec at semver.org allows for "metadata" and it is useful for
deployment tagging. The format is as follows:

`#.#.#-prereleaseName.#+metadata.here`