### PR TITLE
Improvement to support setting the regex per file group. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,40 @@ grunt.initConfig({
 })
 ```
 
+Alternatively, you can use different regexes to your target files:
+
+```js
+grunt.initConfig({
+  bump: {
+    options: {
+      files: [
+        {
+          path: 'index.html',
+          regexp: /(dist\/\w+\/\w+[-])(([\d-]+\.)+[\d]+)(([.\w]+['"]))/g
+        },
+        {
+          path: ['package.json', 'bower.json']
+        }
+      ],
+      updateConfigs: [],
+      commit: true,
+      commitMessage: 'Release v%VERSION%',
+      commitFiles: ['package.json'],
+      createTag: true,
+      tagName: 'v%VERSION%',
+      tagMessage: 'Version %VERSION%',
+      push: true,
+      pushTo: 'upstream',
+      gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
+      globalReplace: false,
+      prereleaseName: false,
+      metadata: '',
+      regExp: false
+    }
+  },
+})
+```
+
 ### Options
 
 #### options.files


### PR DESCRIPTION
Implementation for this feature request: https://github.com/vojtajina/grunt-bump/issues/131

Improvement to support setting the regex per file group. Backwards compatible with the old notation.

New Notation:
files: [
                    {
                        path: 'index.html',
                        regexp: /(dist\/\w+\/\w+[-](([\d-]+\.)+[\d-]+))/g
                    },
                    {
                        path: ['package.json', 'bower.json']
                    }
                ]

Old Notation:
files: ['package.json','package.json', 'bower.json']

If no regexp property is defined within the file, the script falls back to use the regExp prop from the bump config object. If regExp prop is not defined, it uses the built-in default regexp.

Please mind, that I didn't refine the regex matching logic within the code, so you'll have to be careful with your regexes, and mind that the code expects to get the match in a strictly defined order. Use --dry-run to check if everything is ok. 
  