### PR TITLE
feat: support regexp as function

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Default value: `''`
 Allows optional metadata (suffix) for the version number. It is joined to the version with a `+`. This will accept any alphanumeric string, dots (`.`) and dashes (`-`) per the semver spec.
 
 #### options.regExp
-Type: `RegExp`  
+Type: `Function` or `RegExp`
 Default value: `false`
 
 Regex to find and replace version string in files described in `options.files`. If no value is specified, it will use the plugin's default.

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -46,7 +46,7 @@ module.exports = function(grunt) {
     var globalVersion; // when bumping multiple files
     var gitVersion;    // when bumping using `git describe`
 
-    var VERSION_REGEXP = (typeof(opts.regExp) == 'function') ? opts.regExp(opts.prereleaseName) : opts.regExp || new RegExp(
+    var VERSION_REGEXP = (typeof opts.regExp === 'function') ? opts.regExp(opts.prereleaseName) : opts.regExp || new RegExp(
       '([\'|\"]?version[\'|\"]?[ ]*:[ ]*[\'|\"]?)(\\d+\\.\\d+\\.\\d+(-' +
       opts.prereleaseName +
       '\\.\\d+)?(-\\d+)?)[\\d||A-a|.|-]*([\'|\"]?)', 'i'

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -46,7 +46,7 @@ module.exports = function(grunt) {
     var globalVersion; // when bumping multiple files
     var gitVersion;    // when bumping using `git describe`
 
-    var VERSION_REGEXP = opts.regExp || new RegExp(
+    var VERSION_REGEXP = (typeof(opts.regExp) == 'function') ? opts.regExp() : opts.regExp || new RegExp(
       '([\'|\"]?version[\'|\"]?[ ]*:[ ]*[\'|\"]?)(\\d+\\.\\d+\\.\\d+(-' +
       opts.prereleaseName +
       '\\.\\d+)?(-\\d+)?)[\\d||A-a|.|-]*([\'|\"]?)', 'i'

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -46,7 +46,7 @@ module.exports = function(grunt) {
     var globalVersion; // when bumping multiple files
     var gitVersion;    // when bumping using `git describe`
 
-    var VERSION_REGEXP = (typeof(opts.regExp) == 'function') ? opts.regExp() : opts.regExp || new RegExp(
+    var VERSION_REGEXP = (typeof(opts.regExp) == 'function') ? opts.regExp(opts.prereleaseName) : opts.regExp || new RegExp(
       '([\'|\"]?version[\'|\"]?[ ]*:[ ]*[\'|\"]?)(\\d+\\.\\d+\\.\\d+(-' +
       opts.prereleaseName +
       '\\.\\d+)?(-\\d+)?)[\\d||A-a|.|-]*([\'|\"]?)', 'i'


### PR DESCRIPTION
This is useful if you want to reuse options in the RegExp.
eg:

``` js
grunt.initConfig({
  bump: {
    options: {
      regExp: function() {
        return new RegExp('' + grunt.task.current.options.prereleaseName + '');
      }
    }
  }
});
```
