### PR TITLE
feat: add gitPushOptions and gitPushTagOptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ grunt.initConfig({
       tagMessage: 'Version %VERSION%',
       push: true,
       pushTo: 'upstream',
+      gitPushOptions: '',
+      gitPushTagOptions: '',
       gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
       globalReplace: false,
       prereleaseName: false,
@@ -137,6 +139,18 @@ Type: `String`
 Default value: `upstream`
 
 If `options.push` is set to a truthy value, which remote repo should it go to? This is what gets set as `remote` in the `git push {remote} {branch}` command. Use `git remote` to see the list of remote repo's you have listed. [Learn about remote repos](http://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes)
+
+#### options.gitPushOptions
+Type: `String`
+Default value: ``
+
+Options to use with `$ git push`
+
+#### options.gitPushTagOptions
+Type: `String`
+Default value: ``
+
+Options to use with `$ git push vx.y.z`
 
 #### options.gitDescribeOptions
 Type: `String`  

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -17,6 +17,8 @@ module.exports = function(grunt) {
       files: ['package.json'],
       gitCommitOptions: '',
       gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
+      gitPushOptions: '',
+      gitPushTagOptions: '',
       globalReplace: false,
       prereleaseName: false,
       metadata: '',
@@ -227,7 +229,7 @@ module.exports = function(grunt) {
       var cmd;
 
       if (opts.push === 'git' && !opts.pushTo) {
-        cmd = 'git push';
+        cmd = 'git push ' + opts.gitPushOptions;
         if (dryRun) {
           grunt.log.ok('bump-dry: ' + cmd);
           next();
@@ -254,12 +256,12 @@ module.exports = function(grunt) {
         cmd = [];
 
         if (opts.push === true || opts.push === 'branch') {
-          cmd.push('git push ' + opts.pushTo + ' ' + ref.trim());
+          cmd.push('git push ' + opts.pushTo + ' ' + ref.trim() + ' ' + opts.gitPushOptions);
         }
 
         if (opts.createTag && (opts.push === true || opts.push === 'tag')) {
           var tagName = opts.tagName.replace('%VERSION%', globalVersion);
-          cmd.push('git push ' + opts.pushTo + ' ' + tagName);
+          cmd.push('git push ' + opts.pushTo + ' ' + tagName + ' ' + opts.gitPushTagOptions);
         }
 
         cmd = cmd.join(' && ');


### PR DESCRIPTION
added option `gitPushOptions`
added option `gitPushTagOptions`

An interesting use case is for instance if you have a `pre-push` git hook that runs your tests *and* CI that doesn't let you merge your PRs if the tests fail. Then you don't want your tests to run just for a version bump (which usually happens after a checked merge).
The proposed solution is, in this case, to set the `gitPushOptions` to `--no-verify`.

I also added a `gitPushTagOptions` in case it's of some use for some people :)